### PR TITLE
Expose API ports and listen on all bound IPs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ rebuild:
 	docker image build --no-cache -t openworklabs/lotus:latest -f lotus.dockerfile .
 
 run:
-	docker container run --publish 1235:1235 --dns 8.8.8.8 --dns-search example.com --detach --name lotus openworklabs/lotus:latest
+	docker container run -p 1235:1235 -p 1234:1234 --dns 8.8.8.8 --dns-search example.com --detach --name lotus openworklabs/lotus:latest
 
 bash:
-	docker container run --publish 1235:1235 -it --entrypoint=/bin/bash --name lotus --rm openworklabs/lotus:latest
+	docker container run -p 1235:1235 -p 1234:1234 -it --entrypoint=/bin/bash --name lotus --rm openworklabs/lotus:latest
 

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,8 +1,8 @@
 # Default config:
 [API]
-#  ListenAddress = "/ip4/127.0.0.1/tcp/1234/http"
-#  Timeout = "30s"
-#
+  ListenAddress = "/ip4/0.0.0.0/tcp/1234/http"
+  Timeout = "30s"
+
 [Libp2p]
 #  ListenAddresses = ["/ip4/0.0.0.0/tcp/1235", "/ip6/::/tcp/1235"]
 #  ConnMgrLow = 150


### PR DESCRIPTION
This exposes the API ports (`1234`) and configures the lotus API to listen on all bound ports.