### PR TITLE
Generalize cron, add export feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,13 @@ FROM ubuntu:18.04
 #creating cron job to check lotus sync status and restart it if process is killed
 RUN  mkdir /etc/cron.d && \
      mkdir -p /var/spool/cron/crontabs
-COPY scripts/lotus-sync /etc/cron.d
+COPY scripts/cron /etc/cron.d/
 COPY --from=build-env /usr/bin/crontab /usr/bin/crontab
 COPY --from=build-env /etc/init.d/cron /etc/init.d/cron
 COPY --from=build-env /usr/sbin/cron /usr/sbin/cron
 COPY scripts/lotus-sync-restart /bin/lotus-sync-restart
-RUN  crontab -u root /etc/cron.d/lotus-sync
+COPY scripts/lotus-export /bin/lotus-export
+RUN  crontab -u root /etc/cron.d/cron
 
 # Instead of running apt-get just copy the certs and binaries that keeps the runtime image nice and small
 # RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ docker ps
 #### Environment Variables
 
 - `BRANCH` - The git release, tag or branch
+- `LOTUS_EXPORT` - Set to true if you want to export chain snapshots on a daily basis somewhere
+- `LOTUS_EXPORT_PATH` - If LOTUS_EXPORT is set to true - specify whether `.car` file should be saved
 
 #### Volumes
 

--- a/scripts/cron
+++ b/scripts/cron
@@ -1,3 +1,3 @@
 # run lotus-sync-restart every 7 min
 */7 * * * * /bin/lotus-sync-restart
-
+* 0 * * * /bin/lotus-export

--- a/scripts/lotus-export
+++ b/scripts/lotus-export
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Perform a periodic export if export is enabled
+
+if [ "$LOTUS_EXPORT" -eq "true" ]; then
+  lotus chain export $LOTUS_EXPORT_PATH
+fi

--- a/scripts/lotus-export
+++ b/scripts/lotus-export
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 # Perform a periodic export if export is enabled
 
-if [ "$LOTUS_EXPORT" -eq "true" ]; then
+if [[ "$LOTUS_EXPORT" -eq "true" ]]; then
   lotus chain export $LOTUS_EXPORT_PATH
 fi

--- a/scripts/lotus-export
+++ b/scripts/lotus-export
@@ -2,5 +2,6 @@
 # Perform a periodic export if export is enabled
 
 if [[ "$LOTUS_EXPORT" -eq "true" ]]; then
-  lotus chain export $LOTUS_EXPORT_PATH
+  lotus chain export ${LOTUS_EXPORT_PATH}-new
+  mv ${LOTUS_EXPORT_PATH}-new ${LOTUS_EXPORT_PATH}
 fi


### PR DESCRIPTION
This PR introduces a new feature to docker images. By setting `LOTUS_EXPORT` variable end user can enable automatic daily export of chain snapshots to the file described by `LOTUS_EXPORT_PATH` variable.