### PR TITLE
Add lotus shed to the images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update -y && \
 
 RUN git clone https://github.com/filecoin-project/lotus.git --depth 1 --branch $BRANCH && \
     cd lotus && \
-    make clean lotus lotus-shed && \
+    make clean && \
+    make lotus lotus-shed && \
     install -C ./lotus /usr/local/bin/lotus && \
     install -C ./lotus-shed /usr/local/bin/lotus-shed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.14.2 AS build-env
 
 # branch or tag of the lotus version to build
-ARG BRANCH=v0.6.0
+ARG BRANCH=master
 
 RUN echo "Building lotus from branch $BRANCH"
 
@@ -11,9 +11,9 @@ RUN apt-get update -y && \
 
 RUN git clone https://github.com/filecoin-project/lotus.git --depth 1 --branch $BRANCH && \
     cd lotus && \
-    make clean && \
-    make lotus && \
-    install -C ./lotus /usr/local/bin/lotus
+    make clean lotus lotus-shed && \
+    install -C ./lotus /usr/local/bin/lotus && \
+    install -C ./lotus-shed /usr/local/bin/lotus-shed
 
 # runtime container stage
 FROM ubuntu:18.04
@@ -33,6 +33,7 @@ COPY scripts/lotus-sync-restart scripts/lotus-export  /bin/
 RUN  crontab -u root /etc/cron.d/cron
 
 COPY --from=build-env /usr/local/bin/lotus /usr/local/bin/lotus
+COPY --from=build-env /usr/local/bin/lotus-shed /usr/local/bin/lotus-shed
 COPY --from=build-env /etc/ssl/certs /etc/ssl/certs
 COPY --from=build-env /lib/x86_64-linux-gnu /lib/
 COPY LOTUS_VERSION /VERSION

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ docker ps
 - `BRANCH` - The git release, tag or branch
 - `LOTUS_EXPORT` - Set to true if you want to export chain snapshots on a daily basis somewhere
 - `LOTUS_EXPORT_PATH` - If LOTUS_EXPORT is set to true - specify whether `.car` file should be saved
+- `SHEDEXPORT` - Set to true if you want to export chain snapshots using `lotus-shed`
+- `SHEDEXPORTPERIOD` - Defines period of chain snapshotting. Examples: 1m, 1h, 1d
+- `SHEDEXPORTPATH` - Defines path where to export chain snapshot
 
 #### Volumes
 

--- a/scripts/entrypoint
+++ b/scripts/entrypoint
@@ -61,6 +61,14 @@ if [ "$CHAINWATCH" = true ] ; then
     repeat chainwatch run
 fi
 
+if [ "$SHEDEXPORT" = true ] ; then
+    while true; do
+    echo "Exporting state"
+    /usr/local/bin/lotus-shed export --skip-old-msgs --recent-stateroots=900 $SHEDEXPORTPATH
+    timeout $SHEDEXPORTPERIOD /usr/local/bin/lotus daemon
+    done
+fi
+
 if [ "$DAEMON" = true ] ; then
     echo "Starting daemon"
     # Start the daemon process


### PR DESCRIPTION
`Lotus-shed` is a supplementary Lotus binary that contains a lot of tools that can be used to extend Lotus functions. One of the functions required for our Hosted Endpoints is possibility to export chain snapshots fast and efficiently. This update includes `lotus-shed` into `lotus` container and allows to run it using environment variables.